### PR TITLE
fix: escape '-' (dash) to work properly in character class

### DIFF
--- a/FluentRegex.Tests/CompositePatternTests.cs
+++ b/FluentRegex.Tests/CompositePatternTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Text.RegularExpressions;
+using NUnit.Framework;
 
 namespace FluentRegex.Tests
 {
@@ -16,6 +17,9 @@ namespace FluentRegex.Tests
 												  .Word);
 
 			Assert.That(p.ToString(), Is.EqualTo(@"(\d\w)"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 		
 		[Test]
@@ -26,6 +30,9 @@ namespace FluentRegex.Tests
 				.Word);
 
 			Assert.That(p.ToString(), Is.EqualTo(@"(?<Name>\d\w)"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 		
 		[Test]
@@ -48,6 +55,31 @@ namespace FluentRegex.Tests
 												.Word);
 
 			Assert.That(p.ToString(), Is.EqualTo(@"[\d\w]"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
+		}
+		
+		[Test]
+		public void Set_With_Dash()
+		{
+			Pattern p = Pattern.With.Set(Pattern.With.Literal(".- _"));
+
+			Assert.That(p.ToString(), Is.EqualTo(@"[\.\- _]"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
+		}
+		
+		[Test]
+		public void Set_With_Dash_And_Letters()
+		{
+			Pattern p = Pattern.With.Set(Pattern.With.Literal(".- _").Letter);
+
+			Assert.That(p.ToString(), Is.EqualTo(@"[\.\- _a-zA-Z]"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -58,6 +90,9 @@ namespace FluentRegex.Tests
 													   .Word);
 
 			Assert.That(p.ToString(), Is.EqualTo(@"[^\d\w]"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -67,6 +102,9 @@ namespace FluentRegex.Tests
 											Pattern.With.Whitespace);
 
 			Assert.That(p.ToString(), Is.EqualTo("(\\d{3}|\\s)"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -77,16 +115,19 @@ namespace FluentRegex.Tests
 											Pattern.With.Literal("a"));
 
 			Assert.That(p.ToString(), Is.EqualTo("(\\d{3}|\\s|a)"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
 		public void Email()
 		{
-			string regex = @"^[a-zA-Z\d\.-_]+@[a-zA-Z\d\.-]+\.[a-zA-Z]{2,4}$";
+			string regex = @"^[a-zA-Z\d_\-\.]+@[a-zA-Z\d\.\-]+\.[a-zA-Z]{2,4}$";
 
 			Pattern p = Pattern.With
 			                   .StartOfLine
-			                   .Set(Pattern.With.Letter.Digit.Literal(".-_")).Repeat.OneOrMore
+			                   .Set(Pattern.With.Letter.Digit.Literal("_-.")).Repeat.OneOrMore
 			                   .Literal("@")
 			                   .Set(Pattern.With.Letter.Digit.Literal(".-")).Repeat.OneOrMore
 			                   .Literal(".")
@@ -94,12 +135,15 @@ namespace FluentRegex.Tests
 			                   .EndOfLine;
 
 			Assert.That(p.ToString(), Is.EqualTo(regex));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(regex), Throws.Nothing);
 		}
 
 		[Test]
 		public void SSN()
 		{
-			string regex = @"^\d{3}-?\d{2}-?\d{4}$";
+			string regex = @"^\d{3}\-?\d{2}\-?\d{4}$";
 
 			Pattern p = Pattern.With
 							   .StartOfLine
@@ -111,6 +155,9 @@ namespace FluentRegex.Tests
 			                   .EndOfLine;
 
 			Assert.That(p.ToString(), Is.EqualTo(regex));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 	}
 }

--- a/FluentRegex.Tests/RepeatTests.cs
+++ b/FluentRegex.Tests/RepeatTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Text.RegularExpressions;
+using NUnit.Framework;
 
 namespace FluentRegex.Tests
 {
@@ -11,6 +12,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Literal("a").Repeat.OneOrMore;
 
 			Assert.That(p.ToString(), Is.EqualTo("a+"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -19,6 +23,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Literal("a").Repeat.ZeroOrMore;
 
 			Assert.That(p.ToString(), Is.EqualTo("a*"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -27,6 +34,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Literal("a").Repeat.Optional;
 
 			Assert.That(p.ToString(), Is.EqualTo("a?"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -35,6 +45,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Literal("a").Repeat.Times(3);
 
 			Assert.That(p.ToString(), Is.EqualTo("a{3}"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -43,6 +56,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Literal("a").Repeat.Times(3, 5);
 
 			Assert.That(p.ToString(), Is.EqualTo("a{3,5}"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -51,6 +67,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Literal("a").Repeat.AtLeast(3);
 
 			Assert.That(p.ToString(), Is.EqualTo("a{3,}"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -59,6 +78,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Literal("a").Repeat.AtMost(3);
 
 			Assert.That(p.ToString(), Is.EqualTo("a{,3}"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 	}
 }

--- a/FluentRegex.Tests/SimplePatternTests.cs
+++ b/FluentRegex.Tests/SimplePatternTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Text.RegularExpressions;
+using NUnit.Framework;
 
 namespace FluentRegex.Tests
 {
@@ -14,6 +15,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.StartOfLine;
 
 			Assert.That(p.ToString(), Is.EqualTo("^"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -22,6 +26,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.EndOfLine;
 
 			Assert.That(p.ToString(), Is.EqualTo("$"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -30,6 +37,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Anything;
 
 			Assert.That(p.ToString(), Is.EqualTo("."));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -38,6 +48,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Literal("a");
 
 			Assert.That(p.ToString(), Is.EqualTo("a"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -46,6 +59,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Digit;
 
 			Assert.That(p.ToString(), Is.EqualTo("\\d"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -54,6 +70,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.NonDigit;
 
 			Assert.That(p.ToString(), Is.EqualTo("\\D"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -62,6 +81,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Word;
 
 			Assert.That(p.ToString(), Is.EqualTo("\\w"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -70,6 +92,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.NonWord;
 
 			Assert.That(p.ToString(), Is.EqualTo("\\W"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -78,6 +103,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.WordBoundary;
 
 			Assert.That(p.ToString(), Is.EqualTo("\\b"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -86,6 +114,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Letter;
 
 			Assert.That(p.ToString(), Is.EqualTo("a-zA-Z"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -94,6 +125,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.LowercaseLetter;
 
 			Assert.That(p.ToString(), Is.EqualTo("a-z"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -102,6 +136,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.UppercaseLetter;
 
 			Assert.That(p.ToString(), Is.EqualTo("A-Z"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -110,6 +147,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Whitespace;
 
 			Assert.That(p.ToString(), Is.EqualTo("\\s"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -118,6 +158,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.NonWhitespace;
 
 			Assert.That(p.ToString(), Is.EqualTo("\\S"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -126,6 +169,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Tab;
 
 			Assert.That(p.ToString(), Is.EqualTo("\\t"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -134,6 +180,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.CarriageReturn;
 
 			Assert.That(p.ToString(), Is.EqualTo("\\r"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 
 		[Test]
@@ -142,6 +191,9 @@ namespace FluentRegex.Tests
 			Pattern p = Pattern.With.Newline;
 
 			Assert.That(p.ToString(), Is.EqualTo("\\n"));
+			
+			// Check if the regular expression can be compiled without throwing an exception
+			Assert.That(() => new Regex(p.ToString()), Throws.Nothing);
 		}
 	}
 }

--- a/FluentRegex/Pattern.cs
+++ b/FluentRegex/Pattern.cs
@@ -5,7 +5,7 @@ namespace FluentRegex
 {
 	public class Pattern
 	{
-		private const string SPECIAL_CHARS = @"^$.|{}[]()*+?\";
+		private const string SPECIAL_CHARS = @"^$.|{}[]()*+?\-";
 
 		private StringBuilder _builder = new StringBuilder();
 


### PR DESCRIPTION
Me again! 😀 I ran into a problem with a character class and a '-' (dash) in it.

`System.Text.RegularExpressions.RegexParseException: Invalid pattern '[.- _]' at offset 5. [x-y] range in reverse order.`

In a character class, if we want to match a dash, we must escape it. The easiest fix was to add the '-' to the SPECIAL_CHARS and escape it always. This won't affect the Letter properties (a-z, A-Z, ...). In the Literal method, we can either use "-" or "-", and Regex will accept both.

I updated all tests to compile the pattern against the Regex to be absolutely sure that all patterns are working.